### PR TITLE
Introduce Fabric(Crashlytics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -535,3 +535,4 @@ healthchecksdb
 MigrationBackup/
 
 # End of https://www.gitignore.io/api/macos,windows,visualstudio,androidstudio,visualstudiocode
+fabric.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,12 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
 
+apply plugin: 'io.fabric'
+
+repositories {
+    maven { url 'https://maven.fabric.io/public' }
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -62,6 +68,9 @@ dependencies {
     implementation "com.android.support:preference-v7:28.0.0"
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.google.code.gson:gson:2.8.5'
+    implementation ('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
+        transitive = true;
+    }
     testImplementation 'junit:junit:4.12'
     testImplementation "org.apache.httpcomponents:httpclient:4.5.9"
     testImplementation "org.eclipse.jetty:jetty-server:9.4.19.v20190610"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,10 +70,6 @@
                 android:name=".ProxyService"
                 android:enabled="true"
                 android:exported="false"/>
-        <meta-data
-                android:name="io.fabric.ApiKey"
-                android:value="54b12b0855b8dd7c027ccf8896c2def721f4ae7a"
-        />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
             android:required="false"/>
 
     <application
+            android:name=".TspCore"
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
@@ -69,6 +70,10 @@
                 android:name=".ProxyService"
                 android:enabled="true"
                 android:exported="false"/>
+        <meta-data
+                android:name="io.fabric.ApiKey"
+                android:value="54b12b0855b8dd7c027ccf8896c2def721f4ae7a"
+        />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/sokcuri/twimgspeedproxy/TspCore.kt
+++ b/app/src/main/java/com/sokcuri/twimgspeedproxy/TspCore.kt
@@ -1,0 +1,16 @@
+package com.sokcuri.twimgspeedproxy
+
+import android.app.Application
+import com.crashlytics.android.Crashlytics
+import io.fabric.sdk.android.Fabric
+
+class TspCore : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // Crashlytics에 연동해두면 강제종료 발생시 기기 정보는 물론
+        // 다른 스레드의 스택트레이스도 보고됩니다.
+        Fabric.with(this, Crashlytics())
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,16 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
+        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        
+        // https://docs.fabric.io/android/changelog.html#fabric-gradle-plugin
+        classpath 'io.fabric.tools:gradle:1.+'
     }
 }
 


### PR DESCRIPTION
크래시 날 때 기기정보 스택트레이스 이용자통계를 내주는 Fabric에 관한 연동 PR이예요.
https://mobile.twitter.com/LaruYan/status/1146071016105373702


PR 받아들이시고 난 다음에 (프로젝트 최상위)/app/fabric.properties 에

> apiKey=YOUR_FABRIC_API_KEY_PER_ORGANIZATION_HERE
> apiSecret=YOUR_FABRIC_API_SECRET_PER_ORGANIZATION_HERE

작성해주시고 Key나 Secret, Fabric 초대는 이메일로 보내드리거나 Fabric 가입하시고 직접 만드셔서 넣으셔도 되요.

fabric.properties 사용시 일반적인 manifest 방식과는 다르게 키를 안전하게 보관할 수 있지만 안드로이드 스튜디오에서 Instant Run 을 끄셔야 실행시 인식되요.

**커밋에 들어간 API key 는 해당 키가 사용된 Organization을 삭제했으므로 현재 유효하지 않습니다**
